### PR TITLE
Next major version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,14 +8,14 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14, 16, 17]
+        node-version: [16, 18, 20]
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2022 Evologi S.r.l.
+Copyright 2023 Evologi S.r.l.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -472,6 +472,22 @@ Field's width. Required.
 
 All errors that can occur during the parsing or serializing phase contain an error code. Error objects also contain enough info (properties) to debug the problem.
 
+It's possible to detect custom fixed-width errors with their constructor:
+
+```javascript
+import { FixedWidthError } from '@evologi/fixed-width'
+
+try {
+  // parse or stringify...
+} catch (err) {
+  if (err instanceof FixedWidthError) {
+    console.log(err.code)
+  } else {
+    console.log('UNKNOWN_ERROR')
+  }
+}
+```
+
 ### `UNEXPECTED_LINE_LENGTH`
 
 This error is raised when a partial line is found.

--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ npm i @evologi/fixed-width
 import { parse, stringify, Parser, Stringifier } from '@evologi/fixed-width'
 ```
 
-### `parse(stringOrBuffer, options)`
+### `parse(input, options)`
 
-It parses a text or a buffer into an array of elements.
+It parses a text or a buffer into an array of elements. If It receives string of buffer It returns an array of all parsed items. It It receives an iterable (could be `async`), returns the same type of iterable inputted.
 
-- `stringOrBuffer` `<String> | <Buffer>` The raw data to parse.
+- `input` `<String> | <Buffer> | <Iterable> | <AsyncIterable>` The raw data to parse.
 - `options` `<Object>` See [options section](#options).
-- Returns: `<Array>`
+- Returns: `<Array> | <Iterable> | <AsyncIterable>`
 
 ```javascript
 import { parse } from '@evologi/fixed-width'
@@ -92,13 +92,13 @@ const users = parse(text, {
 console.log(users)
 ```
 
-### `stringify(iterable, options)`
+### `stringify(input, options)`
 
-It serializes an array of elements into a string.
+It serializes an array of elements into a string. If the argument is an array, the output will be a string. The whole conversion is performed at the moment and in-memory. If the argument is some kind of iterable (sync or async), the output will be the same kind of inputted iterable.
 
-- `iterable` `<Iterable>` An [iterable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators) that produces the elements to serialize. Arrays are iterable.
+- `input` `<Array> | <Iterable> | <AsyncIterable>`
 - `options` `<Object>` See [options section](#options).
-- Returns: `<String>`
+- Returns: `<String> | <Iterable> | <AsyncIterable>`
 
 ```javascript
 import { stringify } from '@evologi/fixed-width'
@@ -268,18 +268,18 @@ It creates a `Stringifier` instance. This object is useful when a custom optimiz
 
 It consists of only two methods, and all those methods are strictly synchronous.
 
-#### `Stringifier#write(iterable)`
+#### `Stringifier#write(obj)`
 
-It accepts an iterable of objects and returns an iterable of strings where each string represents one stringified object.
+Push an object to serialize. Returns the serialized text of the passed object, including new line terminators.
 
-- `iterable` `<Iterable>`
-- Returns: `<Iterable>`
+- `obj` `<*>`
+- Returns: `<String>`
 
 #### `Stringifier#end()`
 
-Returns the closing iterable of strings.
+Close the parsing and returns a final string.
 
-- Returns: `<Iterable>`
+- Returns: `<String>`
 
 ```javascript
 import { Stringifier } from '@evologi/fixed-width'
@@ -302,16 +302,10 @@ const stringifier = new Stringifier({
   ]
 })
 
-const text = Array.from(
-  stringifier.write([
-    { username: 'alice', age: 24 },
-    { username: 'bob', age: 30 }
-  ])
-).concat(
-  Array.from(
-    stringifier.end()
-  )
-).join('')
+let text = ''
+text += stringifier.write({ username: 'alice', age: 24 })
+text += stringifier.write({ username: 'bob', age: 30 })
+text += stringifier.end()
 
 // 'alice       024\nbob         030\n'
 console.log(text)

--- a/fixed-width.d.ts
+++ b/fixed-width.d.ts
@@ -2,6 +2,18 @@ import { Transform } from "stream";
 
 export interface Options {
   /**
+   * Allow lines to be longer than the declared fields while parsing.
+   *
+   * @default true
+   */
+  allowLongerLines?: boolean;
+  /**
+   * Allow lines to be shorter than the declared fields while parsing.
+   *
+   * @default false
+   */
+  allowShorterLines?: boolean;
+  /**
    * Encoding for both input or output data.
    *
    * @default "utf8"
@@ -34,9 +46,7 @@ export interface Options {
    */
   pad?: string;
   /**
-   * If `true`, partial lines (total width is less than expected) will not throw any error.
-   *
-   * @default false
+   * @deprecated Use `allowLongerLines` and `allowShorterLines` options.
    */
   relax?: boolean;
   /**
@@ -115,8 +125,8 @@ export declare class Stringifier {
    * @constructor
    */
   constructor(options: Options);
-  end(): Buffer;
-  write(iterable: Iterable<any>): Buffer;
+  end(): Iterable<string>;
+  write(iterable: Iterable<any>): Iterable<string>;
 }
 
 export declare function parse<T = unknown>(

--- a/fixed-width.d.ts
+++ b/fixed-width.d.ts
@@ -1,5 +1,10 @@
 import { Transform } from "node:stream";
 
+export declare class FixedWidthError extends Error {
+  code: string;
+  [key: string]: any;
+}
+
 export interface Options {
   /**
    * Allow lines to be longer than the declared fields while parsing.

--- a/fixed-width.d.ts
+++ b/fixed-width.d.ts
@@ -119,8 +119,14 @@ export declare class Parser<T = unknown> {
    * @constructor
    */
   constructor(options: Options);
+  /**
+   * Push a chunk of text. Returns an iterable that yields the parsed objects.
+   */
+  write(chunk: string | Buffer): Iterable<T>;
+  /**
+   * Returns a final iterable that yields the remaining objects (if any).
+   */
   end(): Iterable<T>;
-  write(input: string | Buffer): Iterable<T>;
 }
 
 export declare class Stringifier {
@@ -132,16 +138,49 @@ export declare class Stringifier {
    * @constructor
    */
   constructor(options: Options);
-  end(): Iterable<string>;
-  write(iterable: Iterable<any>): Iterable<string>;
+  /**
+   * Push an object to serialize. Returns the serialized text of the passed object, including new line terminators.
+   */
+  write(obj: object): string;
+  /**
+   * Close the parsing and returns a final string.
+   */
+  end(): string;
 }
 
+/**
+ * Parse objects from buffer or text.
+ *
+ * If the argument is string or buffer, the output will be an array. The whole conversion is performed at the moment and in-memory.
+ *
+ * If the argument is some kind of iterable (sync or async), the output will be the same kind of inputted iterable.
+ */
 export declare function parse<T = unknown>(
   input: string | Buffer,
   options: Options
 ): T[];
-
-export declare function stringify(
-  iterable: Iterable<any>,
+export declare function parse<T = unknown>(
+  input: Iterable<string | Buffer>,
   options: Options
-): string;
+): Iterable<T>;
+export declare function parse<T = unknown>(
+  input: AsyncIterable<string | Buffer>,
+  options: Options
+): AsyncIterable<T>;
+
+/**
+ * Stringify objects to text.
+ *
+ * If the argument is an array, the output will be a string. The whole conversion is performed at the moment and in-memory.
+ *
+ * If the argument is some kind of iterable (sync or async), the output will be the same kind of inputted iterable.
+ */
+export declare function stringify(input: any[], options: Options): string;
+export declare function stringify(
+  input: Iterable<any>,
+  options: Options
+): Iterable<string>;
+export declare function stringify(
+  input: AsyncIterable<any>,
+  options: Options
+): AsyncIterable<string>;

--- a/fixed-width.d.ts
+++ b/fixed-width.d.ts
@@ -1,4 +1,4 @@
-import { Transform } from "stream";
+import { Transform } from "node:stream";
 
 export interface Options {
   /**
@@ -49,6 +49,13 @@ export interface Options {
    * @deprecated Use `allowLongerLines` and `allowShorterLines` options.
    */
   relax?: boolean;
+  /**
+   * Completely ignore all empty lines. This options does **not** change the
+   * behaviour of the `allowShorterLines` option.
+   *
+   * @default true
+   */
+  skipEmptyLines?: boolean;
   /**
    * Ending line to parse.
    *

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "url": "https://github.com/evologi/fixed-width.git"
   },
   "devDependencies": {
-    "ava": "^4.1.0",
-    "c8": "^7.11.0",
-    "rollup": "^2.70.1",
-    "standard": "^16.0.4"
+    "ava": "^5.3.0",
+    "c8": "^7.14.0",
+    "rollup": "^3.23.1",
+    "standard": "^17.1.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,5 +10,9 @@ export default {
       format: 'es'
     }
   ],
-  external: ['stream', 'os']
+  external: [
+    'node:os',
+    'node:stream',
+    'node:string_decoder'
+  ]
 }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,2 +1,3 @@
+export { FixedWidthError } from './error.mjs'
 export { Parser, parse } from './parse.mjs'
 export { Stringifier, stringify } from './stringify.mjs'

--- a/src/index.spec.mjs
+++ b/src/index.spec.mjs
@@ -17,19 +17,19 @@ test('Parser', t => {
 
   t.is(parser.line, 1)
   t.deepEqual(
-    Array.from(parser.write(Buffer.from('helloworld\r'))),
+    Array.from(parser.write('helloworld\r')),
     []
   )
 
   t.is(parser.line, 1)
   t.deepEqual(
-    Array.from(parser.write(Buffer.from('\n'))),
+    Array.from(parser.write('\n')),
     [{ a: 'hello', b: 'world' }]
   )
 
   t.is(parser.line, 2)
   t.deepEqual(
-    Array.from(parser.write(Buffer.from('worldhello\r\n'))),
+    Array.from(parser.write('worldhello\r\n')),
     [{ a: 'world', b: 'hello' }]
   )
 
@@ -44,6 +44,7 @@ test('Parser', t => {
 
 test('Stringifier', t => {
   const stringifier = new Stringifier({
+    eof: true,
     eol: '\r\n',
     fields: [
       { align: 'left', property: 'a', width: 10 },
@@ -54,35 +55,33 @@ test('Stringifier', t => {
 
   t.is(stringifier.line, 1)
   t.is(
-    stringifier
-      .write([
+    Array.from(
+      stringifier.write([
         { a: 'Harry', b: 'Ron', c: 'Hermione' },
         { a: 'Blossom', b: 'Bubbles', c: 'Buttercup' }
       ])
-      .toString(),
-    'Harry            RonHermione  \r\nBlossom      BubblesButtercup '
+    ).join(''),
+    'Harry            RonHermione  \r\nBlossom      BubblesButtercup \r\n'
   )
 
   t.is(stringifier.line, 3)
   t.is(
-    stringifier
-      .write([])
-      .toString(),
+    Array.from(stringifier.write([])).join(''),
     ''
   )
 
   t.is(stringifier.line, 3)
   t.is(
-    stringifier
-      .write([{ a: 'Tom', b: null, c: 'Jerry' }])
-      .toString(),
-    '\r\nTom                 Jerry     '
+    Array.from(
+      stringifier.write([{ a: 'Tom', b: null, c: 'Jerry' }])
+    ).join(''),
+    'Tom                 Jerry     \r\n'
   )
 
   t.is(stringifier.line, 4)
   t.is(
-    stringifier.end().toString(),
-    '\r\n'
+    Array.from(stringifier.end()).join(''),
+    ''
   )
 
   t.is(stringifier.line, 1)

--- a/src/index.spec.mjs
+++ b/src/index.spec.mjs
@@ -56,7 +56,7 @@ test('Stringifier', t => {
 
   t.is(
     stringifier.write(
-      { a: 'Harry', b: 'Ron', c: 'Hermione' },
+      { a: 'Harry', b: 'Ron', c: 'Hermione' }
     ),
     'Harry            RonHermione  \r\n'
   )

--- a/src/index.spec.mjs
+++ b/src/index.spec.mjs
@@ -52,38 +52,36 @@ test('Stringifier', t => {
       { align: 'left', property: 'c', width: 10 }
     ]
   })
-
   t.is(stringifier.line, 1)
-  t.is(
-    Array.from(
-      stringifier.write([
-        { a: 'Harry', b: 'Ron', c: 'Hermione' },
-        { a: 'Blossom', b: 'Bubbles', c: 'Buttercup' }
-      ])
-    ).join(''),
-    'Harry            RonHermione  \r\nBlossom      BubblesButtercup \r\n'
-  )
 
-  t.is(stringifier.line, 3)
   t.is(
-    Array.from(stringifier.write([])).join(''),
-    ''
+    stringifier.write(
+      { a: 'Harry', b: 'Ron', c: 'Hermione' },
+    ),
+    'Harry            RonHermione  \r\n'
   )
+  t.is(stringifier.line, 2)
 
-  t.is(stringifier.line, 3)
   t.is(
-    Array.from(
-      stringifier.write([{ a: 'Tom', b: null, c: 'Jerry' }])
-    ).join(''),
+    stringifier.write(
+      { a: 'Blossom', b: 'Bubbles', c: 'Buttercup' }
+    ),
+    'Blossom      BubblesButtercup \r\n'
+  )
+  t.is(stringifier.line, 3)
+
+  t.is(
+    stringifier.write(
+      { a: 'Tom', b: null, c: 'Jerry' }
+    ),
     'Tom                 Jerry     \r\n'
   )
-
   t.is(stringifier.line, 4)
+
   t.is(
-    Array.from(stringifier.end()).join(''),
+    stringifier.end(),
     ''
   )
-
   t.is(stringifier.line, 1)
 })
 

--- a/src/options.mjs
+++ b/src/options.mjs
@@ -61,6 +61,7 @@ export function parseOptions (options) {
     from,
     output: properties > 0 ? 'object' : 'array',
     pad,
+    skipEmptyLines: options.skipEmptyLines !== false,
     to,
     trim: options.trim === 'left' || options.trim === 'right'
       ? options.trim

--- a/src/options.mjs
+++ b/src/options.mjs
@@ -154,3 +154,11 @@ function isPositiveInteger (value) {
 function isPropertyKey (value) {
   return typeof value === 'string' || typeof value === 'symbol'
 }
+
+export function isIterable (value) {
+  return typeof value !== 'string' && Symbol.iterator in Object(value)
+}
+
+export function isAsyncIterable (value) {
+  return Symbol.asyncIterator in Object(value)
+}

--- a/src/options.mjs
+++ b/src/options.mjs
@@ -14,12 +14,12 @@ export function parseOptions (options) {
   if (typeof pad !== 'string') {
     throw new TypeError('Padding value (pad) must be a string')
   }
-  if (getByteLength(pad, encoding) !== 1) {
-    throw new Error('Padding value (pad) must be a single char (one byte)')
+  if (pad.length !== 1) {
+    throw new Error('Padding value (pad) must be a single char')
   }
 
   const eol = options.eol || ''
-  if (typeof eol !== 'string') {
+  if (typeof eol !== 'string' && !(eol instanceof RegExp)) {
     throw new TypeError('End of line (eol) value must be a string')
   }
 
@@ -48,14 +48,19 @@ export function parseOptions (options) {
   }
 
   return {
+    allowLongerLines: typeof options.relax === 'boolean'
+      ? options.relax
+      : options.allowLongerLines !== false,
+    allowShorterLines: typeof options.relax === 'boolean'
+      ? options.relax
+      : options.allowShorterLines === true,
     encoding,
     eof: options.eof !== false,
-    eol: Buffer.from(eol, encoding),
+    eol,
     fields,
     from,
     output: properties > 0 ? 'object' : 'array',
     pad,
-    relax: options.relax === true,
     to,
     trim: options.trim === 'left' || options.trim === 'right'
       ? options.trim
@@ -95,8 +100,8 @@ function parseField (field, index, defaultColumn, defaultPad, encoding) {
   if (typeof pad !== 'string') {
     throw new TypeError('Padding value (pad) must be a string')
   }
-  if (getByteLength(pad, encoding) !== 1) {
-    throw new Error('Padding value (pad) must be a single char (one byte)')
+  if (pad.length !== 1) {
+    throw new Error('Padding value (pad) must be a single char')
   }
 
   return {
@@ -147,8 +152,4 @@ function isPositiveInteger (value) {
 
 function isPropertyKey (value) {
   return typeof value === 'string' || typeof value === 'symbol'
-}
-
-function getByteLength (value, encoding) {
-  return Buffer.byteLength(value, encoding)
 }

--- a/src/options.spec.mjs
+++ b/src/options.spec.mjs
@@ -1,6 +1,6 @@
 import test from 'ava'
 
-import { parseOptions } from './options.mjs'
+import { isAsyncIterable, isIterable, parseOptions } from './options.mjs'
 
 test('defaults', t => {
   const options = parseOptions({
@@ -62,4 +62,18 @@ test('validation', t => {
     { column: 1, width: 1 },
     { column: 1, width: 1 }
   ]))
+})
+
+test('isIterable', t => {
+  t.false(isIterable(null))
+  t.false(isIterable('test'))
+  t.false(isIterable({}))
+  t.true(isIterable([]))
+})
+
+test('isAsyncIterable', t => {
+  t.false(isAsyncIterable(null))
+  t.false(isAsyncIterable('test'))
+  t.false(isAsyncIterable({}))
+  t.false(isAsyncIterable([]))
 })

--- a/src/options.spec.mjs
+++ b/src/options.spec.mjs
@@ -35,6 +35,7 @@ test('defaults', t => {
     from: 1,
     output: 'array',
     pad: ' ',
+    skipEmptyLines: true,
     to: Number.POSITIVE_INFINITY,
     trim: true,
     width: 4

--- a/src/options.spec.mjs
+++ b/src/options.spec.mjs
@@ -8,11 +8,12 @@ test('defaults', t => {
     fields: [{ width: 2 }, { width: 2 }]
   })
 
-  t.true(Buffer.isBuffer(options.eol))
   t.deepEqual(options, {
+    allowLongerLines: true,
+    allowShorterLines: false,
     encoding: 'utf8',
     eof: true,
-    eol: options.eol,
+    eol: '\n',
     fields: [
       {
         align: 'left',
@@ -34,7 +35,6 @@ test('defaults', t => {
     from: 1,
     output: 'array',
     pad: ' ',
-    relax: false,
     to: Number.POSITIVE_INFINITY,
     trim: true,
     width: 4

--- a/src/parse.mjs
+++ b/src/parse.mjs
@@ -78,11 +78,13 @@ export class Parser {
       this.text = chunks.pop()
 
       for (const chunk of chunks) {
-        yield parseFields(
-          chunk,
-          this.options,
-          this.line++
-        )
+        if (chunk.length > 0 || !this.options.skipEmptyLines) {
+          yield parseFields(
+            chunk,
+            this.options,
+            this.line++
+          )
+        }
       }
     }
   }

--- a/src/parse.mjs
+++ b/src/parse.mjs
@@ -1,5 +1,5 @@
-import { StringDecoder } from 'node:string_decoder'
 import { Transform } from 'node:stream'
+import { StringDecoder } from 'node:string_decoder'
 
 import { FixedWidthError } from './error.mjs'
 import { isAsyncIterable, isIterable, parseOptions } from './options.mjs'

--- a/src/parse.mjs
+++ b/src/parse.mjs
@@ -106,16 +106,16 @@ export function parse (input, options) {
 
 function * parseIterable (iterable, parser) {
   for (const data of iterable) {
-    yield* parser.write(data)
+    yield * parser.write(data)
   }
-  yield* parser.end()
+  yield * parser.end()
 }
 
 async function * parseAsyncIterable (iterable, parser) {
   for await (const data of iterable) {
-    yield* parser.write(data)
+    yield * parser.write(data)
   }
-  yield* parser.end()
+  yield * parser.end()
 }
 
 export function parseFields (text, options, line = 1) {

--- a/src/parse.spec.mjs
+++ b/src/parse.spec.mjs
@@ -173,3 +173,29 @@ test('partial width parsing', t => {
     ['s', 'g']
   ])
 })
+
+test('skip empty lines', t => {
+  const fields = [
+    { width: 1 }
+  ]
+
+  t.like(
+    parse('\na\n\nb\nc\n\n\n', {
+      allowShorterLines: true,
+      eol: '\n',
+      fields,
+      skipEmptyLines: false
+    }),
+    [[''], ['a'], [''], ['b'], ['c'], [''], ['']]
+  )
+
+  t.like(
+    parse('\na\n\nb\nc\n\n\n', {
+      allowShorterLines: true,
+      eol: '\n',
+      fields,
+      skipEmptyLines: true
+    }),
+    [['a'], ['b'], ['c']]
+  )
+})

--- a/src/stringify.mjs
+++ b/src/stringify.mjs
@@ -1,5 +1,5 @@
-import os from 'os'
-import { Transform } from 'stream'
+import os from 'node:os'
+import { Transform } from 'node:stream'
 
 import { FixedWidthError } from './error.mjs'
 import { isAsyncIterable, isIterable, parseOptions } from './options.mjs'

--- a/src/stringify.mjs
+++ b/src/stringify.mjs
@@ -124,10 +124,10 @@ export function stringifyValue (value, encoding) {
   return Buffer.isBuffer(value)
     ? value.toString(encoding)
     : stringifyPrimitiveValue(
-        typeof value === 'object' && value !== null
-          ? value.valueOf()
-          : value
-      )
+      typeof value === 'object' && value !== null
+        ? value.valueOf()
+        : value
+    )
 }
 
 export function stringifyPrimitiveValue (value) {

--- a/src/stringify.spec.mjs
+++ b/src/stringify.spec.mjs
@@ -34,7 +34,7 @@ test('stringify fields', t => {
     b: new Date(42)
   }
 
-  const text = stringifyFields(values, options).toString()
+  const text = stringifyFields(values, options)
   t.is(text, '  1.3 42   ')
 })
 
@@ -78,4 +78,25 @@ test('field level padding', t => {
   )
 
   t.is(buffer.toString(), 'test--0042')
+})
+
+test('stringify utf8', t => {
+  const text = stringify(
+    [
+      ['àà'],
+      ['èè'],
+      ['ìì'],
+      ['òò'],
+      ['ùù']
+    ],
+    {
+      eol: '\n',
+      eof: false,
+      fields: [
+        { width: 2 }
+      ]
+    }
+  )
+
+  t.is(text, 'àà\nèè\nìì\nòò\nùù')
 })


### PR DESCRIPTION
- Add `skipEmptyLines` option
- Add `allowLongerLines` option
- Add `allowShorterLines` option
- Deprecate `relax` option (still used, removed from docs)
- Change return type for `Stringifier`'s methods
- Add support for encoded text (non pure ASCII)
- Support natively sync and async iterables (inside `parse` and `stringify` functions)
- Exported `FixedWidthError` class constructor