### PR TITLE
Implement per-field stringifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,12 @@ Type: `<Number>`
 
 Field's width. Required.
 
+#### `field.stringify`
+
+Type: `<Function>`
+
+A function that converts the field into a custom string. Useful for custom formatting, for example, formatting a Date into DD/MM/YYYY format. Only used while stringifying.
+
 ## Errors
 
 All errors that can occur during the parsing or serializing phase contain an error code. Error objects also contain enough info (properties) to debug the problem.

--- a/fixed-width.d.ts
+++ b/fixed-width.d.ts
@@ -94,6 +94,12 @@ export interface Field {
     context: { column: number; line: number; width: number }
   ) => any;
   /**
+   * Custom way of writing the value to the file
+   */
+  stringify?: (
+    value: any
+  ) => string;
+  /**
    * Field's column number. This is 1-based. First column is 1.
    */
   column?: number;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evologi/fixed-width",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A fixed-width file format toolset with streaming support and flexible options.",
   "type": "module",
   "main": "./fixed-width.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evologi/fixed-width",
-  "version": "1.0.2",
+  "version": "1.0.1",
   "description": "A fixed-width file format toolset with streaming support and flexible options.",
   "type": "module",
   "main": "./fixed-width.cjs",

--- a/src/options.mjs
+++ b/src/options.mjs
@@ -111,6 +111,7 @@ function parseField (field, index, defaultColumn, defaultPad, encoding) {
     column,
     pad,
     property: isPropertyKey(field.property) ? field.property : index,
+    stringify: typeof field.stringify === 'function' ? field.stringify : null,
     width: field.width
   }
 }

--- a/src/options.spec.mjs
+++ b/src/options.spec.mjs
@@ -21,6 +21,7 @@ test('defaults', t => {
         column: 1,
         pad: ' ',
         property: 0,
+        stringify: null,
         width: 2
       },
       {
@@ -29,6 +30,7 @@ test('defaults', t => {
         column: 3,
         pad: ' ',
         property: 1,
+        stringify: null,
         width: 2
       }
     ],

--- a/src/stringify.mjs
+++ b/src/stringify.mjs
@@ -116,7 +116,12 @@ export function replaceWith (text, value, index = 0) {
 }
 
 export function stringifyField (obj, field, options, line) {
-  let value = stringifyValue(obj[field.property], options.encoding)
+  let value = obj[field.property];
+  if(field.stringify) {
+    value = field.stringify(value);
+  }
+  value  = stringifyValue(value, options.encoding)
+
   if (typeof value !== 'string') {
     throw new FixedWidthError(
       'EXPECTED_STRING_VALUE',

--- a/src/stringify.mjs
+++ b/src/stringify.mjs
@@ -116,11 +116,11 @@ export function replaceWith (text, value, index = 0) {
 }
 
 export function stringifyField (obj, field, options, line) {
-  let value = obj[field.property];
-  if(field.stringify) {
-    value = field.stringify(value);
+  let value = obj[field.property]
+  if (field.stringify) {
+    value = field.stringify(value)
   }
-  value  = stringifyValue(value, options.encoding)
+  value = stringifyValue(value, options.encoding)
 
   if (typeof value !== 'string') {
     throw new FixedWidthError(

--- a/src/stringify.spec.mjs
+++ b/src/stringify.spec.mjs
@@ -38,6 +38,31 @@ test('stringify fields', t => {
   t.is(text, '  1.3 42   ')
 })
 
+test('stringify with custom stringifier', t => {
+  const options = parseOptions([
+    {
+      align: 'left',
+      property: 'b',
+      width: 10,
+      stringify: (date) => {
+        // Sample formatting that writes the date in American format (MM/DD/YYYY)
+        const year = (date.getYear() + 1900).toString();
+        const month = date.getMonth().toString().padStart(2, "0");
+        const day = date.getDate().toString().padStart(2, "0");
+        const result = `${month}/${day}/${year}`
+        return result
+      }
+    }
+  ])
+
+  const values = {
+    b: new Date(2020, 3, 15)
+  }
+
+  const text = stringifyFields(values, options)
+  t.is(text, '03/15/2020')
+})
+
 test('expected string value', t => {
   t.throws(
     () => stringify(

--- a/src/stringify.spec.mjs
+++ b/src/stringify.spec.mjs
@@ -46,9 +46,9 @@ test('stringify with custom stringifier', t => {
       width: 10,
       stringify: (date) => {
         // Sample formatting that writes the date in American format (MM/DD/YYYY)
-        const year = (date.getYear() + 1900).toString();
-        const month = date.getMonth().toString().padStart(2, "0");
-        const day = date.getDate().toString().padStart(2, "0");
+        const year = (date.getYear() + 1900).toString()
+        const month = date.getMonth().toString().padStart(2, '0')
+        const day = date.getDate().toString().padStart(2, '0')
         const result = `${month}/${day}/${year}`
         return result
       }


### PR DESCRIPTION
This implements a per-field stringifier, so that you can customize how each field is written. Effectively, it's the opposite of the `cast` option.